### PR TITLE
Feature/add azure support

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -82,6 +82,7 @@
   </div>
 
   <div *ngIf="(selectedPlatform == 'AWS Lambda') && (selectedState == availableFunctionStates.cold) && (selectedStartDate < coldStartIncludesInitDurationStartDate)" class="spf-warning-message">Note that cold-start tests recorded before 5th March 2020 only recorded execution duration and did not record initialization time</div> 
+  <div *ngIf="(errorMessage != '')" class="spf-error-message">{{errorMessage}}</div> 
 
   <!-- Data Table -->
   <table mat-table [dataSource]="dataSource" matSort #spfSort="matSort" matSortActive="mean" matSortDirection="asc" class="mat-elevation-z8">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,7 +22,7 @@
         <mat-grid-tile>
           <mat-form-field class="spf-filter-select">
             <mat-label>Serverless Platform:</mat-label>
-            <mat-select [(value)]="selectedPlatform" (selectionChange)="refreshMetricsData()">
+            <mat-select [(value)]="selectedPlatform" (selectionChange)="updateServerlessPlatformSelection()">
               <mat-option value="AWS Lambda">AWS</mat-option>
               <mat-option value="Azure Functions">Azure</mat-option>
             </mat-select>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,6 +24,7 @@
             <mat-label>Serverless Platform:</mat-label>
             <mat-select [(value)]="selectedPlatform" (selectionChange)="refreshMetricsData()">
               <mat-option value="AWS Lambda">AWS</mat-option>
+              <mat-option value="Azure Functions">Azure</mat-option>
             </mat-select>
           </mat-form-field>
         </mat-grid-tile>
@@ -43,8 +44,8 @@
               <mat-label>Memory Size:</mat-label>
               <mat-select [(value)]="selectedMemory" (selectionChange)="refreshMetricsData()">
                 <mat-option value="128">128 MB</mat-option>
-                <mat-option value="256">256 MB</mat-option>
-                <mat-option value="512">512 MB</mat-option>
+                <mat-option *ngIf="(selectedPlatform == 'AWS Lambda')" value="256">256 MB</mat-option>
+                <mat-option *ngIf="(selectedPlatform == 'AWS Lambda')" value="512">512 MB</mat-option>
               </mat-select>
           </mat-form-field>
         </mat-grid-tile>    
@@ -53,7 +54,8 @@
           <mat-form-field class="spf-filter-select">
             <mat-label>Region:</mat-label>
             <mat-select [(value)]="selectedRegion" (selectionChange)="refreshMetricsData()">
-              <mat-option value="us-east-1">us-east-1</mat-option>
+              <mat-option *ngIf="(selectedPlatform == 'AWS Lambda')" value="us-east-1">us-east-1</mat-option>
+              <mat-option *ngIf="(selectedPlatform == 'Azure Functions')" value="east-us">East US</mat-option>
             </mat-select>
           </mat-form-field>   
         </mat-grid-tile> 
@@ -79,7 +81,7 @@
     </mat-form-field>
   </div>
 
-  <div *ngIf="(selectedState == availableFunctionStates.cold) && (selectedStartDate < coldStartIncludesInitDurationStartDate)" class="spf-warning-message">Note that cold-start tests recorded before 5th March 2020 only recorded execution duration and did not record initialization time</div> 
+  <div *ngIf="(selectedPlatform == 'AWS Lambda') && (selectedState == availableFunctionStates.cold) && (selectedStartDate < coldStartIncludesInitDurationStartDate)" class="spf-warning-message">Note that cold-start tests recorded before 5th March 2020 only recorded execution duration and did not record initialization time</div> 
 
   <!-- Data Table -->
   <table mat-table [dataSource]="dataSource" matSort #spfSort="matSort" matSortActive="mean" matSortDirection="asc" class="mat-elevation-z8">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -288,8 +288,23 @@
     color: white;
 
     border-radius: 4px;
-    background-color: red;
+    background-color: orange;
   }
+
+  .spf-error-message {
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-top: 10px;
+    margin-bottom: 20px;
+    color: white;
+
+    border-radius: 4px;
+    background-color: red;
+  }  
 
   .spf-recordcount {
     font-size: 8px;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,7 +43,8 @@ export class AppComponent {
     "nodejs12x": "NodeJS 12.x",
     "go": "Golang 1.x",
     "ruby25": "Ruby 2.5",
-    "ruby27": "Ruby 2.7"
+    "ruby27": "Ruby 2.7",
+    "dotnet31csx": ".NET Core 3.1"
   };
 
   title = 'Serverless Performance Framework';
@@ -76,6 +77,13 @@ export class AppComponent {
   }
 
   @ViewChild('spfSort', {static: true}) spfSort: MatSort;
+
+  updateServerlessPlatformSelection() {
+    // select first option in dropdowns that have different contents depending on platform
+    this.selectedMemory = '128';
+    this.selectedRegion = (this.selectedPlatform == 'AWS Lambda') ? 'us-east-1' : 'east-us';
+    this.refreshMetricsData();
+  }
 
   refreshMetricsData() {
     // clear table
@@ -131,7 +139,8 @@ export class AppComponent {
   }  
 
   showAWSData() {
-    environment.runtimes.forEach(runtime => {
+    let runtimes = (this.selectedPlatform == 'AWS Lambda') ? environment.aws_runtimes : environment.azure_runtimes;
+    runtimes.forEach(runtime => {
       this.getSummary(runtime, this.selectedState);
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -66,6 +66,7 @@ export class AppComponent {
   selectedEndDate = new Date(this.maxDate);
 
   invalidInputs = false;
+  errorMessage = "";
 
   constructor(private spfapiservice: SpfapiService) {
     let thirtyDaysAgo = new Date(new Date().setDate(new Date().getDate()-30));
@@ -89,6 +90,7 @@ export class AppComponent {
     // clear table
     this.metricsData = [];
     this.dataSource = new MatTableDataSource(this.metricsData);
+    this.errorMessage = "";
 
     // request fresh data
     this.showAWSData();
@@ -122,6 +124,7 @@ export class AppComponent {
     this.spfapiservice.getSummary(this.selectedPlatform, runtime, state, this.selectedMemory, this.selectedRegion, this.selectedStartDate, this.selectedEndDate)
       .subscribe((data: SummaryResponseModel) => { 
         if (data.minExecution != null) {
+          // we got valid data
           this.metricsData.push({
             runtime: this.displayRuntimeMap[runtime], 
             max: parseFloat(this.getExecutionDuration(data.maxExecution)).toFixed(2), 
@@ -134,6 +137,15 @@ export class AppComponent {
           });
           this.dataSource = new MatTableDataSource(this.metricsData);
           this.dataSource.sort = this.spfSort;
+        }
+        else {
+          // an error occurred - report error to screen
+          if (this.errorMessage == "") {
+            this.errorMessage = `Failed to retrieve data for the following runtimes (please try again later): ${this.displayRuntimeMap[runtime]}`;
+          }
+          else {
+            this.errorMessage += `, ${this.displayRuntimeMap[runtime]}`;
+          }
         }
     });
   }  

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,5 +2,6 @@ export const environment = {
   production: true,
   envName: "prod",
   baseUrl: "https://api.serverlessperformance.net",
-  runtimes: ['java8', 'java11', 'ruby25', 'ruby27', 'python36', 'python38', 'go', 'dotnet21', 'nodejs12x', 'nodejs10x'] 
+  aws_runtimes: ['java8', 'java11', 'ruby25', 'ruby27', 'python36', 'python38', 'go', 'dotnet21', 'nodejs12x', 'nodejs10x'], 
+  azure_runtimes: ['dotnet31csx', 'nodejs12x', 'nodejs10x'] 
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,7 +6,8 @@ export const environment = {
   production: false,
   envName: "dev",
   baseUrl: "https://api.serverlessperformance.net",
-  runtimes: ['java8', 'java11', 'ruby25', 'ruby27', 'python36', 'python38', 'go', 'dotnet21', 'nodejs12x', 'nodejs10x'] 
+  aws_runtimes: ['java8', 'java11', 'ruby25', 'ruby27', 'python36', 'python38', 'go', 'dotnet21', 'nodejs12x', 'nodejs10x'], 
+  azure_runtimes: ['dotnet31csx', 'nodejs12x', 'nodejs10x'] 
 };
 
 /*


### PR DESCRIPTION
Adds support for Azure data display - closes #5 
Also adds error handling if timeouts/errors occur on the calls to SPF API

Compatible with release 3.1.0 of https://github.com/Learnspree/Serverless-Language-Performance-Framework
